### PR TITLE
Add support for CoreML conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# CoreML
+CoreML_Models/

--- a/CoreMLWrapper.py
+++ b/CoreMLWrapper.py
@@ -1,0 +1,18 @@
+import torch
+import torch.nn as nn
+from model import Generator
+
+class CoreMLWrapper(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.generator = Generator()
+
+    def forward(self, input):
+        # First run the underlying generator
+        out = self.generator(input)
+
+        # Now do the clamping and scaling (moved from the Generator's forward)
+        out = torch.clamp(out, -1, 1) + 1
+        out = out * (255.0 / 2)
+
+        return out

--- a/README.md
+++ b/README.md
@@ -126,4 +126,32 @@ Trained on <b>512x512</b> face images. Compared to v1, `🔻beautify` `🔺robus
 
 </details>
 
+## CoreML Conversion
+CoreML conversions support versions of Python up to 3.11, and the `torch` module up to `2.5.0`.
 
+1. Install python 3.11 (Latest supported version by CoreML)
+2. [Optional] Setup a virtual environment
+```shell
+python3.11 -m venv venv
+. venv/bin/activate
+# Run `deactivate` to deactivate the virtual environment
+```
+3. Install requirements
+```shell
+pip install -r requirements
+```
+4. Convert the models
+```shell
+python convert_to_coreml.py
+```
+5. Test the CoreML models
+```shell
+# Use a default sample image
+python coreml_test.py
+
+# Or specify a path to another input image
+python coreml_test.py /path/to/input_image.jpg
+```
+
+### Wrapping the model
+The original model outputs an ImageType with normalized color values in the range [-1, 1]. CoreML expects those values to be restored to their 8-bit range [0, 255].  The CoreMLWrapper class handles this post-processing.  Without this, CoreML will assume that the values are 8-bit, which will mean most of the values will be near zero, leaving you with an image that looks entirely black.

--- a/convert_to_coreml.py
+++ b/convert_to_coreml.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import torch
+import torchvision.io as io
+import coremltools as ct
+import os
+from model import Generator
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+weights_dir = os.path.join(SCRIPT_DIR, "weights")
+coreml_dir = os.path.join(SCRIPT_DIR, "CoreML_Models")
+
+def convert_to_coreml(
+    pytorch_weights_filename="face_paint_512_v1.pt",
+    coreml_package_filename="FacePaintV1.mlpackage"
+):
+    pytorch_model_path = os.path.join(weights_dir, pytorch_weights_filename)
+    coreml_model_path = os.path.join(coreml_dir, coreml_package_filename)
+
+    # Instantiate model and load weights.
+    model = Generator()
+    model.load_state_dict(torch.load(pytorch_model_path, map_location="cpu", weights_only=True))
+    model.eval()
+
+    # Create a dummy input of the fixed shape used during export.
+    example_input = torch.randn(1, 3, 1024, 1024)
+
+    # Use a tensor from a real image instead of a randomly generated tensor
+    #
+    # input_image = Image.open("/path/to/sample.jpg").resize((1024, 1024))
+    # to_tensor = transforms.ToTensor()
+    # input_tensor = to_tensor(input_image)
+    # input_batch = input_tensor.unsqueeze(0)
+
+    traced_model = torch.jit.trace(model, example_input)
+
+    # Supporting dynamic images
+    #
+    # Set the input_shape to use RangeDim for each dimension.
+    # input_shape = ct.Shape(shape=(1,
+    #                             3,
+    #                             ct.RangeDim(lower_bound=25, upper_bound=2048, default=1024),
+    #                             ct.RangeDim(lower_bound=25, upper_bound=2048, default=1024)))
+    
+    input_shape = ct.EnumeratedShapes(shapes=[[1, 3, 256, 256],
+                                              [1, 3, 1024, 1024]],
+                                              default=[1, 3, 256, 256])
+
+    # Convert to Core ML
+    mlmodel = ct.convert(
+        traced_model,
+        inputs=[
+            ct.ImageType(
+                name="input_image",
+                shape=[1, 3, 1024, 1024],
+                scale=2/255.0,
+                bias=[-1.0, -1.0, -1.0],
+            )
+        ],
+        outputs=[
+            ct.ImageType(
+                name="output_image",
+                # scale=1.0,      # CoreML requires a scale of 1.0
+                # bias=[0.0, 0.0, 0.0],
+                color_layout=ct.colorlayout.RGB
+            )
+        ]
+    )
+
+    mlmodel.save(coreml_model_path)
+    print(f"Core ML model saved to {coreml_model_path}")
+
+if __name__ == "__main__":
+    if not os.path.exists(coreml_dir):
+        os.makedirs(coreml_dir)
+
+    convert_to_coreml("face_paint_512_v1.pt", "FacePaintV1.mlpackage")
+    convert_to_coreml("face_paint_512_v2.pt", "FacePaintV2.mlpackage")
+    convert_to_coreml("paprika.pt", "Paprika.mlpackage")
+    convert_to_coreml("celeba_distill.pt", "CelebA_Distill.mlpackage")

--- a/convert_to_coreml.py
+++ b/convert_to_coreml.py
@@ -4,7 +4,7 @@ import torch
 import torchvision.io as io
 import coremltools as ct
 import os
-from model import Generator
+from CoreMLWrapper import CoreMLWrapper
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 weights_dir = os.path.join(SCRIPT_DIR, "weights")
@@ -18,8 +18,8 @@ def convert_to_coreml(
     coreml_model_path = os.path.join(coreml_dir, coreml_package_filename)
 
     # Instantiate model and load weights.
-    model = Generator()
-    model.load_state_dict(torch.load(pytorch_model_path, map_location="cpu", weights_only=True))
+    model = CoreMLWrapper()
+    model.generator.load_state_dict(torch.load(pytorch_model_path, map_location="cpu", weights_only=True))
     model.eval()
 
     # Create a dummy input of the fixed shape used during export.

--- a/coreml_test.py
+++ b/coreml_test.py
@@ -1,0 +1,37 @@
+import coremltools as ct
+from PIL import Image
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+coreml_dir = os.path.join(SCRIPT_DIR, "CoreML_Models")
+
+# Dynamically discover mlpackage model filenames from CoreML_Models
+model_filenames = [
+    fname for fname in os.listdir(coreml_dir)
+    if fname.endswith(".mlpackage")
+]
+
+# Load a sample image
+if len(sys.argv) > 1:
+    input_image_path = sys.argv[1]
+else:
+    input_image_path = os.path.join("samples", "inputs", "1.jpg")
+input_image = Image.open(input_image_path).convert("RGB").resize((1024, 1024))
+
+for filename in model_filenames:
+    print(f"Testing model: {filename}")
+    # Load Core ML model
+    model_path = os.path.join(coreml_dir, filename)
+    mlmodel = ct.models.MLModel(model_path)
+
+    # Print the model specification for verification
+    print(mlmodel.get_spec())
+
+    # Run a prediction. Provide the PIL Image since the model expects an ImageType.
+    result = mlmodel.predict({"input_image": input_image})
+
+    # Extract the output image
+    output_image = result["output_image"]
+    output_image.show()
+    print(f"Finished testing {filename}\n")

--- a/model.py
+++ b/model.py
@@ -107,8 +107,5 @@ class Generator(nn.Module):
 
         out = self.out_layer(out)
 
-        out = torch.clamp(out, -1, 1) + 1
-        out = out * (255.0 / 2)
-
         return out
         

--- a/model.py
+++ b/model.py
@@ -93,18 +93,20 @@ class Generator(nn.Module):
         out = self.block_b(out)
         out = self.block_c(out)
         
-        if align_corners:
-            out = F.interpolate(out, half_size, mode="bilinear", align_corners=True)
-        else:
-            out = F.interpolate(out, scale_factor=2, mode="bilinear", align_corners=False)
+        upsample = nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False)
+        out = upsample(out)
         out = self.block_d(out)
 
-        if align_corners:
-            out = F.interpolate(out, input.size()[-2:], mode="bilinear", align_corners=True)
-        else:
-            out = F.interpolate(out, scale_factor=2, mode="bilinear", align_corners=False)
+        upsample = nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False)
+        out = upsample(out)
+
         out = self.block_e(out)
 
         out = self.out_layer(out)
+
+        # CoreML expects the color values to be [0, 255]
+        out = torch.clamp(out, -1, 1) + 1
+        out = out * (255.0 / 2)
+
         return out
         

--- a/model.py
+++ b/model.py
@@ -93,18 +93,20 @@ class Generator(nn.Module):
         out = self.block_b(out)
         out = self.block_c(out)
         
-        upsample = nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False)
-        out = upsample(out)
+        if align_corners:
+            out = F.interpolate(out, half_size, mode="bilinear", align_corners=True)
+        else:
+            out = F.interpolate(out, scale_factor=2, mode="bilinear", align_corners=False)
         out = self.block_d(out)
 
-        upsample = nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False)
-        out = upsample(out)
-
+        if align_corners:
+            out = F.interpolate(out, input.size()[-2:], mode="bilinear", align_corners=True)
+        else:
+            out = F.interpolate(out, scale_factor=2, mode="bilinear", align_corners=False)
         out = self.block_e(out)
 
         out = self.out_layer(out)
 
-        # CoreML expects the color values to be [0, 255]
         out = torch.clamp(out, -1, 1) + 1
         out = out * (255.0 / 2)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-torch >= 1.7.1
+--find-links https://download.pytorch.org/whl/metal.html  # For installing older versions of torch
+torch==2.5.0  # Required for CoreML
 torchvision
+coremltools


### PR DESCRIPTION
This adds support for converting the PyTorch models into CoreML models:

- Adds a `CoreMLWrapper` class to handle image post-processing
- Updates the `requirements.txt` to satisfy the requirements of CoreML conversion
- Adds two scripts:
   - `convert_to_coreml.py`: Generates the CoreML models
   - `coreml_test.py`: Tests the CoreML models using a sample image